### PR TITLE
SpringBoot 버전업, spring profile 구분, dockerfile 세팅

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM adoptopenjdk/openjdk11:alpine
-ARG JAR_FILE
+ARG JAR_FILE=build/libs/\*.jar
+ARG PROFILE=local-docker
+ENV PROFILE_ENV ${PROFILE}
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=${PROFILE_ENV}"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.3.9.RELEASE'
+	id 'org.springframework.boot' version '2.4.3'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 }
@@ -13,7 +13,7 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "Hoxton.SR10")
+	set('springCloudVersion', "2020.0.3")
 }
 
 dependencyManagement {
@@ -25,10 +25,10 @@ dependencyManagement {
 
 dependencies {
 	compile("org.springframework.cloud:spring-cloud-starter-gateway")
-	compile("org.springframework.cloud:spring-cloud-starter-netflix-hystrix")
-	compile("org.springframework.cloud:spring-cloud-starter-contract-stub-runner"){
-		exclude group: "org.springframework.boot", module: "spring-boot-starter-web"
-	}
+//	compile("org.springframework.cloud:spring-cloud-starter-netflix-hystrix")
+//	compile("org.springframework.cloud:spring-cloud-starter-contract-stub-runner"){
+//		exclude group: "org.springframework.boot", module: "spring-boot-starter-web"
+//	}
 	testCompile("org.springframework.boot:spring-boot-starter-test")
 
 	compileOnly 'org.projectlombok:lombok:1.18.10'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,19 +1,46 @@
+# 공통
+
 server:
   port: 8081
 
 spring:
   profiles:
-    active: local
----
-
-spring:
-  profiles: local
+    active: local   # 프로파일 지정 없으면 디폴트로 local 사용
   cloud:
     gateway:
       default-filters:
         - name: JwtRequestFilter
           args:
             baseMessage: Spring Cloud Gateway GlobalFilter
+      # CORS configuration
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOriginPatterns: "*"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - OPTIONS
+              - DELETE
+            allowedHeaders:
+              - x-requested-with
+              - authorization
+              - content-type
+              - credential
+              - X-AUTH-TOKEN
+              - X-CSRF-TOKEN
+            allow-credentials: true # 쿠키, 인증헤더 허용
+
+---
+
+# 로컬 IDE기반 개발용 프로파일
+spring:
+  config:
+    activate:
+      on-profile: local
+  cloud:
+    gateway:
       routes:
         - id: post-svc
           uri: http://localhost:8082/
@@ -54,42 +81,19 @@ spring:
             - Path=/fcm/**
           filters:
             - RewritePath=/fcm/(?<segment>.*), /$\{segment}
-      # CORS configuration
-      globalcors:
-        cors-configurations:
-          '[/**]':
-            allowedOrigins: "*"
-            allowedMethods:
-              - GET
-              - POST
-              - PUT
-              - OPTIONS
-              - DELETE
-            allowedHeaders:
-              - x-requested-with
-              - authorization
-              - content-type
-              - credential
-              - X-AUTH-TOKEN
-              - X-CSRF-TOKEN
-            allow-credentials: true # 쿠키, 인증헤더 허용
 
 ---
 
-## 운영서버 배포용
+## 로컬에서 도커로 띄워놓을때 사용하는 프로파일
 spring:
-  profiles: prod
+  config:
+    activate:
+      on-profile: local-docker
   cloud:
     gateway:
-      default-filters:
-        - name: JwtRequestFilter
-          args:
-            baseMessage: Spring Cloud Gateway GlobalFilter
-            preLogger: true
-            postLogger: true
       routes:
         - id: post-svc
-          uri: http://13.124.17.116:8082/
+          uri: http://host.docker.internal:8082/
           predicates:
             - Path=/main/**
           filters:
@@ -99,24 +103,31 @@ spring:
                 baseMessage: Spring Cloud Gateway PostFilter
                 preLogger: true
                 postLogger: true
-      # CORS configuration
-      globalcors:
-        cors-configurations:
-          '[/**]':
-            allowedOrigins:
-              - "http://13.124.17.116:8080"
-              - "http://54.180.97.84:8080"
-              - "http://13.124.121.251:8080"
-            allowedMethods:
-              - GET
-              - POST
-              - PUT
-              - OPTIONS
-              - DELETE
-            allowedHeaders:
-              - x-requested-with
-              - authorization
-              - content-type
-              - credential
-              - X-AUTH-TOKEN
-              - X-CSRF-TOKEN
+        - id: chat-ws-svc
+          uri: ws://host.docker.internal:8083/
+          predicates:
+            - Path=/chat/chat-conn/**
+          filters:
+            - RewritePath=/chat/(?<segment>.*), /$\{segment}
+            - name: ChatMessageFilter
+              args:
+                baseMessage: Sprint Cloud Gateway ChatMessageFilter
+                preLogger: true
+                postLogger: true
+        - id: chat-http-svc
+          uri: http://host.docker.internal:8083/
+          predicates:
+            - Path=/chat/**
+          filters:
+            - RewritePath=/chat/(?<segment>.*), /$\{segment}
+            - name: ChatFilter
+              args:
+                baseMessage: Sprint Cloud Gateway ChatFilter
+                preLogger: true
+                postLogger: true
+        - id: fcm-svc
+          uri: http://host.docker.internal:8084/
+          predicates:
+            - Path=/fcm/**
+          filters:
+            - RewritePath=/fcm/(?<segment>.*), /$\{segment}


### PR DESCRIPTION
1. local에서 서버를 IDE로 키지 않고 container로 켜놓을 수 있게 하기 위해 local container용 spring profile 설정.
2. Docker build 편리하게 할 수 있도록 Dockerfile 작성
3. spring profile 설정시 SpringBoot 2.4버전 전후로 설정방법이 달라지기 때문에
  다른 서버 프로젝트들과의 통일성 위해 2.3.9 -> 2.4.3으로 업그레이드 하였음.